### PR TITLE
Add basic smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,15 @@
     "es6",
     "modules"
   ],
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "broccoli-filter": "^1.2.4"
+  },
+  "devDependencies": {
+    "broccoli-test-helper": "^1.2.0",
+    "co": "^4.6.0",
+    "jest": "^21.2.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const co = require('co');
+
+const helper = require('broccoli-test-helper');
+const createBuilder = helper.createBuilder;
+const createTempDir = helper.createTempDir;
+
+const JsonModule = require('./index');
+
+describe('JsonModule', () => {
+  let input, output;
+
+  beforeEach(co.wrap(function *() {
+    input = yield createTempDir();
+
+    let subject = new JsonModule(input.path());
+    output = createBuilder(subject);
+  }));
+
+  afterEach(co.wrap(function *() {
+    yield input.dispose();
+    yield output.dispose();
+  }));
+
+  it('should build', co.wrap(function *() {
+    input.write({
+      'a.json': '{"foo": 42}',
+      'lib': {
+        'b.json': '{"bar": 13}',
+        'c.js': 'export default { baz: 37 };',
+      }
+    });
+
+    yield output.build();
+
+    expect(output.read()).toEqual({
+      'a.js': 'export default {"foo": 42};',
+      'lib': {
+        'b.js': 'export default {"bar": 13};',
+        'c.js': 'export default { baz: 37 };',
+      }
+    });
+  }));
+});

--- a/test.js
+++ b/test.js
@@ -41,5 +41,16 @@ describe('JsonModule', () => {
         'c.js': 'export default { baz: 37 };',
       }
     });
+
+    input.write({
+      'a.json': '{"foo": 73}',
+      'lib': null
+    });
+
+    yield output.build();
+
+    expect(output.read()).toEqual({
+      'a.js': 'export default {"foo": 73};',
+    });
   }));
 });


### PR DESCRIPTION
This PR adds a basic smoke test to the repo using `broccoli-test-helper` and `jest. It is also using `co` to simplify the Promise chains using generator functions for Node 4 and 6.
